### PR TITLE
Remove cron schedule

### DIFF
--- a/.github/workflows/alerts.yml
+++ b/.github/workflows/alerts.yml
@@ -1,8 +1,6 @@
 name: MTA Alert Updater
 
 on:
-  schedule:
-    - cron: "*/5 * * * *"  # Every 5 minutes
   workflow_dispatch:       # Optional: manual trigger
 
 jobs:


### PR DESCRIPTION
Moved script to a server that properly executes the job. GitHub actions was incredibly inconsistent causing large delays in executions.